### PR TITLE
add endian.h include for non-linux platforms

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -14,7 +14,7 @@
 
 #include "crypto/equihash.h"
 #include "util.h"
-
+#include "compat/endian.h"
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
An ifdef or something from ./configure should trigger this include when the platform is not linux, but for now we're just going to add it