### PR TITLE
fix mv command in README-mac

### DIFF
--- a/README-mac.md
+++ b/README-mac.md
@@ -35,8 +35,7 @@ cd zcash
 git checkout v1.0.0-mac-gcc
 ./zcutil/build-mac.sh
 ```
-When you are done building, you need to do a few things in the [Configuration](https://github.com/zcash/zcash/wiki/1.0-User-Guide#configuration) section of the Zcash User Guide differently because we are on the Mac. All instances of ```~/.zcash``` need to be replaced by ```~/Library/Application\ Support/Zcash``` and after you run ```./zcutil/fetch-params.sh``` you need to 
-run ```mv ~/.zcash-params "~/Library/Application\ Support/ZcashParams"``` 
+When you are done building, you need to do a few things in the [Configuration](https://github.com/zcash/zcash/wiki/1.0-User-Guide#configuration) section of the Zcash User Guide differently because we are on the Mac. All instances of `~/.zcash` need to be replaced by `~/Library/Application\ Support/Zcash` and after you run `./zcutil/fetch-params.sh` you need to run `mv ~/.zcash-params ~/Library/Application\ Support/ZcashParams`
 
 Happy Building,
 


### PR DESCRIPTION
removed double quotes from the path because it's already escaped by the backslash. I also removed some triple-backticks