### PR TITLE
An attempt to reduce compiler and linker errors in Windows build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -470,8 +470,9 @@ libzcashconsensus_la_SOURCES = \
   script/script.cpp \
   uint256.cpp \
   utilstrencodings.cpp \
-  util.cpp
-
+  util.cpp \
+  zcash/JoinSplit.cpp
+    
 if GLIBC_BACK_COMPAT
   libzcashconsensus_la_SOURCES += compat/glibc_compat.cpp
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -471,14 +471,18 @@ libzcashconsensus_la_SOURCES = \
   uint256.cpp \
   utilstrencodings.cpp \
   util.cpp \
-  zcash/JoinSplit.cpp
+  chainparamsbase.cpp \
+  utiltime.cpp \
+  random.cpp \
+  support/cleanse.cpp \
+  $(LIBZCASH_H) 
     
 if GLIBC_BACK_COMPAT
   libzcashconsensus_la_SOURCES += compat/glibc_compat.cpp
 endif
 
 libzcashconsensus_la_LDFLAGS = -no-undefined $(RELDFLAGS)
-libzcashconsensus_la_LIBADD = $(CRYPTO_LIBS) $(BOOST_LIBS) $(EXTRA_LIBRARIES)
+libzcashconsensus_la_LIBADD = $(CRYPTO_LIBS) $(BOOST_LIBS) $(LIBZCASH)
 libzcashconsensus_la_CPPFLAGS = $(CRYPTO_CFLAGS) -I$(builddir)/obj -DBUILD_BITCOIN_INTERNAL
 
 endif

--- a/zcutil/build-win.sh
+++ b/zcutil/build-win.sh
@@ -2,7 +2,7 @@
 
 # sanitize path because the one we get from Windows is garbage with spaces in it and
 # the makefiles in depends don't quote the path when they hand it to bash for ./configure
-export PATH=/mingw64/bin/:/usr/local/bin:/usr/bin:/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+export PATH=/C/msys64/mingw64/bin/:/usr/local/bin:/usr/bin:/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
 
 HOST="x86_64-pc-mingw64"
 

--- a/zcutil/build-win.sh
+++ b/zcutil/build-win.sh
@@ -2,7 +2,7 @@
 
 # sanitize path because the one we get from Windows is garbage with spaces in it and
 # the makefiles in depends don't quote the path when they hand it to bash for ./configure
-export PATH=/C/msys64/mingw64/bin/:/usr/local/bin:/usr/bin:/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+export PATH=/C/msys64/mingw64/bin:/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
 
 HOST="x86_64-pc-mingw64"
 


### PR DESCRIPTION
In this PR reduction in compiler and linker errors are attempted. The changes in each commit remedy one certain failure to either link or compile. There are currently at least two errors on linking

**Sodium**
equihash.cpp:49: undefined reference to `crypto_generichash_blake2b_update'
equihash.cpp:50: undefined reference to `crypto_generichash_blake2b_final'

**Boost**
undefined reference to `boost::system::generic_category

There are possibly more failures.

*** DO NOT MERGE. ***